### PR TITLE
Fix issue detected by sonarqube

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>com.olx.ci</groupId>
 	<artifactId>helloworld-example</artifactId>
 	<packaging>jar</packaging>
-	<version>1.0.0-SNAPSHOT</version>
+	<version>1.0.1-SNAPSHOT</version>
 
 	<distributionManagement>
 		<repository>

--- a/src/main/java/hello/Message.java
+++ b/src/main/java/hello/Message.java
@@ -1,7 +1,6 @@
 package hello;
 
 public class Message {
-    public String sayHello() {
-        return "Hi, How are you?";
-    }
+    public String sayHello = new String("Hi, How are you?");
+
 }


### PR DESCRIPTION
There's no point in forcing the overhead of a method call for a method that always returns the same constant value. Even worse, the fact that a method call must be made will likely mislead developers who call the method thinking that something more is done. Declare a constant instead.

This rule raises an issue if on methods that contain only one statement: the return of a constant value.
Noncompliant Code Example